### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "automated"
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
This PR adds Dependabot configuration with the following settings:

- Weekly checks for Go module updates
- Automatic PR creation with a limit of 10 open PRs
- Labels: dependencies, automated
- Commit message prefix: deps